### PR TITLE
small typos

### DIFF
--- a/arith.tex
+++ b/arith.tex
@@ -46,7 +46,7 @@ $\Arith$ program; so $5$ is an $\Arith$ program by
 an $\Arith$ program by (2).  And therefore
 $\Mult(\Pred(5),5)$ is an $\Arith$ program by
 (5).  The recipe lets us build up bigger and bigger expressions from
-other expressions.  
+other expressions.
 
 Interpreted as a checking procedure, we can answer the question ``is
 $\Plus(4,\Succ(2))$ an $\Arith$ program?''  It
@@ -61,10 +61,10 @@ $\Arith$ is to use a BNF grammar:
 
 \[
 \begin{array}{lrcll}
-\mathbb{Z} 
+\mathbb{Z}
                & \mint & ::= & \dots\ |\ -1\ |\ 0\ |\ 1\ |\ \dots\\
- \Arith 
-               & e & ::= & i \\ % & \text{where }i\in\mathbb{Z}\\ 
+ \Arith
+               & e & ::= & i \\ % & \text{where }i\in\mathbb{Z}\\
                &   & |   & \Pred(e)\\
                &   & |   & \Succ(e)\\
                &   & |   & \Plus(e,e)\\
@@ -73,11 +73,11 @@ $\Arith$ is to use a BNF grammar:
 \]
 
 In both of these definitions, the occurrences of ``$\mint$'' and
-``$\mexp$'' are occurrences of \deftech{meta-variables}---the are
+``$\mexp$'' are occurrences of \deftech{meta-variables}---they are
 variables in the language describing the programming language (in this
 case $\Arith$).  The describing language itself (in this case math,
 but often it is another programming language) is called the
-\deftech{meta-language}, while the described languaged ($\Arith$) is
+\deftech{meta-language}, while the described language ($\Arith$) is
 called the \deftech{object-language}.  By convention, the name of a
 meta-variable signals the set of values it ranges over.  So for
 example a meta-variable $\mint$ may refer to $5$ or $17$, but never
@@ -158,11 +158,11 @@ earlier mathematical definition\footnote{Already a lie has crept in:
 language:
 %
 \begin{verbatim}
-   type arith = Int of int 
+   type arith = Int of int
               | Pred of arith
               | Succ of arith
               | Plus of arith * arith
-              | Mult of arith * arith 
+              | Mult of arith * arith
 \end{verbatim}
 The only difference, which is inconsequential, is that OCaml, unlike
 math, requires unions to be formed by disjoint types, so integers must
@@ -214,7 +214,7 @@ well.
 \end{mathpar}
 
 
-\paragraph{Note on notation:} 
+\paragraph{Note on notation:}
 %
 To be truly pedantic, we should add hypotheses to each of the inference
 rules that state $e \in \Arith$ and $i \in \mathbb{Z}$ and so
@@ -249,7 +249,7 @@ proof that $\Plus(4,\Succ(2)) \Downarrow 7$.
 
 When reading these inference rules, it's important to notice that the
 right hand side of the evaluation relation is a mathematical
-expression that denotes an integer; not a peice of syntax.  As the
+expression that denotes an integer; not a piece of syntax.  As the
 previous example shows, $\Plus(4,\Succ(2))$ evaluates to $7$; not a
 representation of the expression ``4+(2+1)''.  If it helps to see
 this, a completely equivalent formulation of, for example, the $\Plus$
@@ -268,11 +268,11 @@ $\Downarrow$ function as a function in a programming language such as
 OCaml.  It naturally is a recursive function over the data type of
 syntax:
 \begin{verbatim}
-   let rec eval (e : arith) : int = 
+   let rec eval (e : arith) : int =
        match e with
          Int i -> i
        | Pred e -> (eval e) - 1
-       | Succ e -> (eval e) + 1        
+       | Succ e -> (eval e) + 1
        | Plus (e1, e2) -> (eval e1) + (eval e2)
        | Mult (e1, e2) -> (eval e1) * (eval e2)
 \end{verbatim}
@@ -295,7 +295,7 @@ is adequate.
 
 This brings up several questions.  What is a semantics for?  Why would
 one semantics be preferred over another?  What other kind of semantics
-could there possible be?
+could there possibly be?
 
 \subsection{Reduction Semantics}
 
@@ -306,7 +306,7 @@ semantics.''  The program properties of interest depend on what you
 are trying to accomplish.  Are you trying to write a correct
 interpreter?  The natural semantics is probably what you need since it
 tells you what value the interpreter should produce.  Are you trying
-to prove upper bounds on the cost of runnning some programs?  The
+to prove upper bounds on the cost of running some programs?  The
 natural semantics won't work because it doesn't say \emph{anything}
 about cost.  Ditto if you want to prove a program can run forever
 without using all available memory.  So a semantics should be tailored
@@ -314,7 +314,7 @@ to properties of interest.
 
 With that in mind, let's investigate a semantics that informs us of each
 of the steps a computation goes through toward reaching a value.  This
-is useful for determing, for example, if two programs reach the same
+is useful for determining, for example, if two programs reach the same
 intermediate state, or in which order are operations performed during a
 computation.  In other words, such a semantics would tell us more
 about \emph{how} a program evaluates.
@@ -350,7 +350,7 @@ $\Plus(4,\Succ(2))$ doesn't step to anything.  The
 reason is that our axioms only apply when the arguments to operators
 are integers, which is not the case here.  It is true that
 $\Succ(2)$ steps to $3$, but none of the rules allows us to
-evaluate inside of a nested expression.  
+evaluate inside of a nested expression.
 
 
 
@@ -399,7 +399,7 @@ Using $\step$, we can see that $\Plus(4,\Succ(2))
 \step \Plus(4,3)$ and $\Plus(4,3) \step 7$.
 %
 Evaluation of a program can be viewed a series of related expressions
-arriving at a final answer.  
+arriving at a final answer.
 
 If we'd like to capture the notion of ``$e$ steps to $e'$ in any
 number of steps,'' we can define yet another relation, $\multistep\;
@@ -516,12 +516,12 @@ a list.  Therefore the signature of {\tt step\_a} will be {\tt arith ->
 \begin{verbatim}
    let rec step_a (e : arith) : arith list =
      match a e with
-       | None -> 
+       | None ->
            (match e with
               | Int i -> []
               | Pred e -> List.map (fun e' -> Pred e') (step_a e)
               | Succ e -> List.map (fun e' -> Succ e') (step_a e)
-              | Plus (e1, e2) -> 
+              | Plus (e1, e2) ->
                   let f e1s e2s = List.map
                     (fun (e1',e2') -> Plus (e1', e2'))
                     (cartesian e1s e2s)
@@ -538,7 +538,7 @@ a list.  Therefore the signature of {\tt step\_a} will be {\tt arith ->
 where
 \begin{verbatim}
    let cartesian (l : 'a list) (l' : 'b list) : ('a * 'b) list =
-     List.concat (List.map (fun e -> List.map (fun e' -> (e,e')) l') l) 
+     List.concat (List.map (fun e -> List.map (fun e' -> (e,e')) l') l)
 \end{verbatim}
 Some examples:
 \begin{verbatim}
@@ -587,7 +587,7 @@ reduce (one step) in parallel.
 
   You have a design choices to make for $\laxparstep$: it can allow
   any amount of parallelism, or it can impose a maximal amount of parallelism.
-  % 
+  %
   Let's call the more lax any amount of parallelism relation
   $\laxparstep$ and the maximal one $\maxparstep$.  The key difference
   is that $\laxparstep$ should relate
@@ -605,7 +605,7 @@ step, this program can either become $\Plus(4,\Pred(5))$ or
 $\Plus(\Succ(3),4)$.  So modelling $\step$ as a function in, say,
 OCaml can't be accomplished quite so easily as with $\Downarrow$.  One
 idea for modelling a finite relation in a functional language is to
-rely on the isomorphism 
+rely on the isomorphism
 \[
 (X \times X) \cong (X \longrightarrow \mathcal{P}(X))\text.
 \]
@@ -630,7 +630,7 @@ single set consisting of the element the partial function maps to.
 This has the nice property that it is consistent with the functional
 view of relations from the previous exercise, since
 \[
-(X \longrightarrow (\emptyset + \{X\})) \subseteq 
+(X \longrightarrow (\emptyset + \{X\})) \subseteq
 (X \longrightarrow \mathcal{P}(X))\text.
 \]
 Write an OCaml function \syntax{reduce} that represents $\reduce$
@@ -746,8 +746,8 @@ plugged in the hole.''
 This context-based formulation may seem like just a somewhat more
 compact notation for specifying the tedious compatibility inference
 rules that allow reduction to happen inside of subexpressions, but it
-also does something more signficant: it gives a name to the context in
-which a reduction occurs; naming something gives us control
+also does something more significant: it gives a name to the context in
+which a reduction occurs; naming something gives us control over
 it.\footnote{Computer science is in many ways the science of names.}
 We will examine some of the possibilities later in the notes.
 
@@ -766,7 +766,7 @@ Having a ``calculus of programs,'' as embodied by the equational
 theory for our language, is important to reason about programs and
 equivalences between them, but when trying to find what a program
 reduces it, it's better if we had a strategy for the mechanical
-calculuation of answers.  For the $\Arith$ language, it's easy to see
+calculation of answers.  For the $\Arith$ language, it's easy to see
 that any strategy will do: as long as you keep reducing something,
 you'll always find the correct answer eventually; it doesn't matter
 what order you go in.  For richer languages, it's not always clear
@@ -776,7 +776,7 @@ exists!).
 
 Establishing a strategy for the order in which a machine applies
 reduction axioms to obtain an answer is called a \deftech{standard
-  reduction semantics}; it represent a canonical way in which programs
+  reduction semantics}; it represents a canonical way in which programs
 are reduced.
 
 
@@ -835,7 +835,7 @@ and $\mexp_2$ are values, in which case the $\areducename$ rule
 applies.
 
 The rules for reducing inside expressions are not quite compatibility
-rules because they do not allow a reduction axiom to be apply to
+rules because they do not allow a reduction axiom to be applied to
 \emph{any} subexpression.  Instead, they encode a \deftech{reduction
   strategy} that specifies the one subexpression where an axiom may be
 applied.
@@ -851,10 +851,10 @@ $\areducename$:
               | Int i -> []
               | Pred e -> List.map (fun e' -> Pred e') (step_a e)
               | Succ e -> List.map (fun e' -> Succ e') (step_a e)
-              | Plus (e1, e2) -> 
+              | Plus (e1, e2) ->
                   let f e1s e2s = List.map
                     (fun (e1',e2') -> Plus (e1', e2'))
-                    (cartesian e1s e2s)            
+                    (cartesian e1s e2s)
                   in
                     (match e1 with
                       | Int i -> (f [e1] (standard_step_a e2))
@@ -940,7 +940,7 @@ The standard semantics has the following desirable properties:
 \begin{enumerate}
 %% \item it is a function,
 %% \[
-%% \bvstdstep\menv\mexp{\mexp'} \wedge 
+%% \bvstdstep\menv\mexp{\mexp'} \wedge
 %% \bvstdstep\menv\mexp{\mexp''} \Rightarrow \mexp'=\mexp''\text,
 %% \]
 \item if the standard semantics produces a value, it is consistent with the reduction semantics,
@@ -1008,17 +1008,17 @@ let rec decompose (e : arith) : (ecxt * arith) option =
   | Succ (Int i) -> Some (Hole, e)
   | Plus (Int i, Int j) -> Some (Hole, e)
   | Mult (Int i, Int j) -> Some (Hole, e)
-  | Pred e -> 
+  | Pred e ->
     let Some (c', e') = decompose e in Some (EPred c', e')
-  | Succ e -> 
+  | Succ e ->
     let Some (c', e') = decompose e in Some (ESucc c', e')
-  | Plus (Int i, e) -> 
+  | Plus (Int i, e) ->
     let Some (c', e') = decompose e in Some (EPlusR (i, c'), e')
   | Plus (e, e2) ->
     let Some (c', e') = decompose e in Some (EPlusL (c', e2), e')
-  | Mult (Int i, e) -> 
+  | Mult (Int i, e) ->
     let Some (c', e') = decompose e in Some (EMultR (i, c'), e')
-  | Mult (e, e2) -> 
+  | Mult (e, e2) ->
     let Some (c', e') = decompose e in Some (EMultL (c', e2), e')
 \end{verbatim}
 This code relies on the following (easy to prove) fact that if an
@@ -1032,7 +1032,7 @@ process until a value is reached:
 let rec eval (e : arith) : int =
   match e with
     Int i -> i
-  | _ -> 
+  | _ ->
     let Some (c, e') = decompose e in
     let Some r = a e' in
     eval (plug c r)
@@ -1056,7 +1056,7 @@ What is a compiler?
 
 One view is the following: a compiler is a function that consumes a
 program and produces a program, which when run produces the same
-result as the given progam.
+result as the given program.
 
 In other words,
 \begin{verbatim}
@@ -1106,10 +1106,10 @@ of syntactic case analysis for the expression being run:
    let rec compile_2 (e : arith) : (unit -> int) =
      match e with
        | Int i -> (fun () -> i)
-       | Pred e -> 
+       | Pred e ->
           let c = compile_2 e in
             (fun () -> c () - 1)
-       | Succ e -> 
+       | Succ e ->
           let c = compile_2 e in
             (fun () -> c () + 1)
        | Plus (e1, e2) ->
@@ -1131,7 +1131,7 @@ arithmetic operations and function calls to run code.
 \subsection{Again, with Ambiguity}
 
 Let's now replay the development of the various formulations of
-$\Arith$ with the slighest addition to the language.  Let's add the
+$\Arith$ with the slightest addition to the language.  Let's add the
 following form of expression: $\Amb(\mexp_1,\mexp_2)$, which we'll
 take to mean ``evaluate, ambiguously, to either the value of $\mexp_1$
 or $\mexp_2$''.
@@ -1154,18 +1154,18 @@ integers.  Because of this, we will run into trouble with our {\tt
 of the mathematical definition of $\Downarrow$ into OCaml in the
 presence of $\Amb$:
 \begin{verbatim}
-   type arith = 
-     | Int of int 
+   type arith =
+     | Int of int
      | Pred of arith
      | Succ of arith
      | Plus of arith * arith
-     | Mult of arith * arith 
+     | Mult of arith * arith
 
-   let rec eval (e : arith) : int = 
+   let rec eval (e : arith) : int =
        match e with
        | Int i -> i
        | Pred e -> (eval e) - 1
-       | Succ e -> (eval e) + 1        
+       | Succ e -> (eval e) + 1
        | Plus (e1, e2) -> (eval e1) + (eval e2)
        | Mult (e1, e2) -> (eval e1) * (eval e2)
        | Amb (e1, e2) -> eval e1
@@ -1188,7 +1188,7 @@ integers.  While OCaml has a nice, general purpose set library, an
 easy hack is to represent a set as a list.  Therefore the signature of
 {\tt eval} will be {\tt arith -> int list}.
 
-Let's take the function in peices:
+Let's take the function in pieces:
 \begin{verbatim}
 let rec eval (e : arith) : int list =
   match e with
@@ -1228,9 +1228,9 @@ the Cartesian product of two given lists.
 %
 Now the cases for addition and multiplication are easy:
 \begin{verbatim}
-  | Plus (e1, e2) -> 
+  | Plus (e1, e2) ->
       List.map (fun (v1,v2) -> v1+v2) (cartesian (eval e1) (eval e2))
-  | Mult (e1, e2) -> 
+  | Mult (e1, e2) ->
       List.map (fun (v1,v2) -> v1*v2) (cartesian (eval e1) (eval e2))
 \end{verbatim}
 Finally we have the case of $\Amb$.  Suppose we have $\Amb(\mexp_1,\mexp_2)$ where,
@@ -1249,11 +1249,11 @@ Putting it all together, we have:
 let rec eval (e : arith) : int list =
   match e with
   | Int i -> [i]
-  | Pred e -> 
+  | Pred e ->
       List.map (fun v -> v-1) (eval e)
   | Succ e ->
       List.map (fun v -> v+1) (eval e)
-  | Plus (e1, e2) -> 
+  | Plus (e1, e2) ->
       List.map (fun (v1,v2) -> v1+v2) (cartesian (eval e1) (eval e2))
   | Mult (e1, e2) ->
       List.map (fun (v1,v2) -> v1*v2) (cartesian (eval e1) (eval e2))

--- a/barith.tex
+++ b/barith.tex
@@ -47,7 +47,7 @@ The $\Arith$ language is about as simple a programming language as
 you're likely to find, although it served us well in demonstrating many
 of the core ideas behind syntax and semantics.
 %
-As programmers, we like programming in rich, expressive languages, 
+As programmers, we like programming in rich, expressive languages,
 which $\Arith$ ain't.
 %
 But as we enrich languages, we must also enrich our models.
@@ -72,7 +72,7 @@ $\False$.  Finally, for good measure, let's throw in variables so that
 programs run on given inputs.  We'll call this language $\Barith$ to
 distinguish it from $\Arith$.
 
-The syntax of $\Barith$ is straightfoward to define.  We add a couple
+The syntax of $\Barith$ is straightforward to define.  We add a couple
 nullary constructors for Booleans, a binary constructor for equality
 and for division, and a ternary constructor for conditionals.  For
 variables, we assume there is an infinite, enumerable set of variable
@@ -214,7 +214,7 @@ type barith =
   | Div of barith * barith
 
 type value =
-  | VInt of int 
+  | VInt of int
   | VBool of bool
   | VError of string
 
@@ -235,7 +235,7 @@ let rec compile (e : barith) : (env -> value) =
              VInt (i-1))
     | Succ e ->
         let c = compile e in
-          (fun env -> 
+          (fun env ->
              let VInt i = c env in
                VInt (i+1))
     | Mult (e1, e2) ->
@@ -301,7 +301,7 @@ given in terms of an environment.
 
 The $\bstepname$ relation is the closure of $\breducename$ for
 compatibility with the syntax of expressions; The $\bmultistepname$
-relation is the relfexive, transitive closure of the $\bstepname$
+relation is the reflexive, transitive closure of the $\bstepname$
 relation.  The $=_\breducename$ equivalence relation is the symmetric
 closure of the $\bmultistepname$ relation.  The syntactic theory is
 consistent and standard reduction relation $\bstdstepname$ can be
@@ -330,7 +330,7 @@ is not a value and cannot step further, we say it is \deftech{stuck}.
 
 
 
-%%%%% 
+%%%%%
 \subsection{Meaningful Errors}
 
 The development of the previous section, which essentially ignores
@@ -343,10 +343,10 @@ explicitly.  For example, we may want to know what kinds of errors are
 possible, and if errors are possible, which code component is at fault
 for the error.  In the remainder of this section, we look at various
 ways of modelling errors for our simple language.  Although this is a
-simpified setting, we will see that errors, which are a primitive form
+simplified setting, we will see that errors, which are a primitive form
 of \deftech{effect}, complicate reasoning about programs.  In
 particular, we must be careful in designing the syntactic theory in
-order to remaing consistent.
+order to remain consistent.
 
 
 For a proper account of error behavior, we need to designate a set of
@@ -429,9 +429,9 @@ We need similar rules for all of the remaining syntactic constructors.
 Now that the semantics is in place, let's step back and consider some
 of its properties.  The addition of errors has significantly
 complicated the formal development---we had to add a bunch of rules
-for signal and propogating errors.  But dealing with errors and
+for signal and propagating errors.  But dealing with errors and
 establishing the meaning of errors is a crucial aspect of semantic
-engineering.  Remember that a semantics is useful for definining
+engineering.  Remember that a semantics is useful for defining
 properties of programs, and one of the more useful properties is
 ``this program causes no errors.''  So to even talk about this, we
 need to confront error behaviors in the semantics.
@@ -602,7 +602,7 @@ $\compat\bep$, and $=_\bep$ as the symmetric closure of
 $\multicompat\bep$.
 
 Note that this theory allows us to reduce inside of $\If$ expressions,
-but if an error occurs, we cannot propogate it out until the test
+but if an error occurs, we cannot propagate it out until the test
 expression produces a value and the $\If$ is reduced to the consequent
 or alternative based on it.
 
@@ -683,4 +683,3 @@ The example now immediately jumps to the final error state:
 Prove $\envreduce\mexp{\multistd{\be}}\mans \iff
 \envreduce\mexp{\multistd{\bep}}\mans$.
 \end{exercise}
-

--- a/redex.tex
+++ b/redex.tex
@@ -14,7 +14,7 @@ the semantic engineering life-cycle.
 
 \subsection{Racket: a General-Purpose Host Language}
 
-Redex is a domain-specific language (DSL) embeded within the
+Redex is a domain-specific language (DSL) embedded within the
 general-purpose language Racket.  Racket is a descendant of Lisp and
 adopts much of Lisp's fully parenthesized prefix notation.  It comes
 with an interactive development environment, called DrRacket, and has
@@ -22,7 +22,7 @@ a large corpus of libraries.  It has been developed over the last
 twenty or so years by the PLT research group, which is distributed
 across several different universities in the USA.  The group has
 developed Racket in part to support their educational work and in part
-as a vehicle for researching programming languages.  
+as a vehicle for researching programming languages.
 
 The basic unit of code in Racket is a module, which must first declare
 which language it is written in with the {\tt \#lang} directive:
@@ -65,7 +65,7 @@ figure~\ref{fig:drracket}.
 
 
 The interactions area has a prompt for accepting expressions to
-evaluate.  Any definitions from the module are avaiable within the
+evaluate.  Any definitions from the module are available within the
 interactions window, so we can experiment and calculate other results
 of factorial:
 \begin{verbatim}
@@ -103,7 +103,7 @@ Defining the syntax of a language is accomplished with {\tt
   define-language}, which gives the grammar of terms for the language:
 \begin{verbatim}
 (define-language A
-  (e ::= 
+  (e ::=
      v
      (Pred e)
      (Succ e)
@@ -200,13 +200,13 @@ achieved with:
 \end{verbatim}
 A {\tt reduction-relation} specifies which language it operates on, in
 this case {\tt A}.  The language determines the interpretation of the
-meta-variables (and what whether a peice of syntax is a
+meta-variables (and what whether a piece of syntax is a
 meta-variable).  The relation is written as a set of axioms, each of
 which has the form {\tt (--> $L\;R\;\mathit{name}$)} where $L$ is a
 \deftech{pattern} and $R$ is a \deftech{template} and $\mathit{name}$
 is an optional name for the rule.  Applying a reduction relation to a
 term matches the term against each pattern and if the match is
-succesful produces the template with each meta-variable replaced by
+successful produces the template with each meta-variable replaced by
 the corresponding substructure of the pattern match.
 
 A reduction relation can be applied with {\tt apply-reduction-relation}:
@@ -264,8 +264,8 @@ metafunction in Redex:
 (define-metafunction A
   [(eval v) v]
   [(eval (Pred e)) ,(sub1 (term (eval e)))]
-  [(eval (Succ e)) ,(add1 (term (eval e)))]  
-  [(eval (Plus e_1 e_2)) 
+  [(eval (Succ e)) ,(add1 (term (eval e)))]
+  [(eval (Plus e_1 e_2))
    ,(+ (term (eval e_1))
        (term (eval e_2)))]
   [(eval (Mult e_1 e_2))
@@ -292,9 +292,9 @@ a {\tt term}:
 It's important to notice that this defines a \emph{function}, not a
 \emph{relation}.  Since we know that $\Downarrow$ for $\Arith$ is a
 function, this is a correct model of $\Downarrow$, but it would not be
-if $\Downarrow$ were realy a relation, such as with the natural
+if $\Downarrow$ were really a relation, such as with the natural
 semantics of imprecise errors for $\Barith$.  To model relations (that
-are not reduction relations), we need another mecahnism: {\tt
+are not reduction relations), we need another mechanism: {\tt
   define-judgment-form}.
 
 \subsection{Contexts}
@@ -332,8 +332,8 @@ Since each of these rules has a repeated structure of using {\tt
 (define -->a
   (reduction-relation
    A
-   (~~> (Pred i) ,(sub1 (term i)))                                                              
-   (~~> (Succ i) ,(add1 (term i)))                                                                   
+   (~~> (Pred i) ,(sub1 (term i)))
+   (~~> (Succ i) ,(add1 (term i)))
    (~~> (Mult i j) ,(* (term i) (term j)))
    (~~> (Plus i j) ,(+ (term i) (term j)))
    with
@@ -360,7 +360,7 @@ Defining a relation is accomplished with the {\tt
    (evalr (Pred e) ,(sub1 (term v)))]
   [(evalr e v)
    -----------
-   (evalr (Succ e) ,(add1 (term v)))]  
+   (evalr (Succ e) ,(add1 (term v)))]
   [(evalr e_1 v_1)
    (evalr e_2 v_2)
    ---------------
@@ -374,7 +374,7 @@ Defining a relation is accomplished with the {\tt
 A judgment is a relation that is being modelled computationally as a
 function.  The {\tt \#:mode} keyword gives a mode specification which
 declares which parts of the relation can be consider inputs ({\tt I})
-and which parts can be considered outouts ({\tt O}), which can be
+and which parts can be considered outputs ({\tt O}), which can be
 thought of as specifying which positions are inputs and outputs in
 this function.
 
@@ -421,8 +421,8 @@ example, here is a model of the natural numbers and a formulation of
    ---------------
    (>= (S N_0) N_1)])
 
-(define ->>= 
-  (reduction-relation 
+(define ->>=
+  (reduction-relation
    Natural
    (--> N_0 N_1
         (judgment-holds (>= N_0 N_1)))))
@@ -455,7 +455,7 @@ iterating the standard reduction relation are exactly equal to the set
 of values related by the natural semantics relation.  Redex will
 generate random expressions and search for a counterexample with {\tt
   redex-check}:
-\begin{verbatim}                                                                          
+\begin{verbatim}
 > (redex-check A e
                (equal? (apply-reduction-relation* -->a (term e))
                        (judgment-holds (evalr e v) v)))
@@ -497,7 +497,7 @@ We can now extend the syntax of {\tt A} to obtain {\tt B}:
      (If e e e))
   (x ::= variable)
   (v ::= .... b)
-  (b ::= True False) 
+  (b ::= True False)
   (ρ ::= ((x v) ...))
   (E ::= ....
      (Div E e)
@@ -517,16 +517,16 @@ The reduction relation {\tt a} can be lifted to work on {\tt B}
 expressions and unioned with the new reduction axioms:
 \begin{verbatim}
 (define (b ρ)
-  (union-reduction-relations 
+  (union-reduction-relations
    (extend-reduction-relation a B)
    (reduction-relation
     B
     (--> x v (where v (lookup ,ρ x)))
     (--> (Div i j) ,(quotient (term i) (term j))
-         (side-condition (not (zero? (term j)))))    
+         (side-condition (not (zero? (term j)))))
     (--> (Eq i i) True)
     (--> (Eq i j) False
-         (side-condition (not (= (term i) (term j)))))    
+         (side-condition (not (= (term i) (term j)))))
     (--> (If True e_1 e_2) e_1)
     (--> (If False e_1 e_2) e_2))))
 \end{verbatim}
@@ -537,7 +537,7 @@ variable if it exists, or produced {\tt \#f}:
 (define-metafunction B
   lookup : ρ x -> v or #f
   [(lookup ((x v) (x_0 v_0) ...) x) v]
-  [(lookup ((x_0 v_0) (x_1 v_1) ...) x) 
+  [(lookup ((x_0 v_0) (x_1 v_1) ...) x)
    (lookup ((x_1 v_1) ...) x)]
   [(lookup () x) #f])
 \end{verbatim}
@@ -585,7 +585,7 @@ depths.
 
 Now let's look at the second clause:
 \begin{verbatim}
-  [(lookup ((x_0 v_0) (x_1 v_1) ...) x) 
+  [(lookup ((x_0 v_0) (x_1 v_1) ...) x)
    (lookup ((x_1 v_1) ...) x)]
 \end{verbatim}
 This pattern matches whenever the environment contains one or more
@@ -599,7 +599,7 @@ structurally smaller environment.
 Programming with Redex's souped-up pattern matcher takes some getting
 used to.  Try things out.  Make conjectures with test cases.
 
-\begin{exercise} 
+\begin{exercise}
 Design a metafunction {\tt pukool} which is like {\tt lookup} but
 searches through the environment from right to left.  The following
 test cases demonstrate the difference:
@@ -619,9 +619,9 @@ extension:
   (e ::= .... r)
   (r ::= (Err variable))
   (a ::= v r))
- 
+
 (define err
-  (reduction-relation 
+  (reduction-relation
    BE
    (--> (Div i 0) (Err Div0))
    (--> (Div b v) (Err Div1))
@@ -640,13 +640,13 @@ extension:
    (--> (Mult r e) r)
    (--> (Mult v r) r)
    (--> (Div r e) r)
-   (--> (Div v r) r)    
+   (--> (Div v r) r)
    (--> (Eq r e) r)
    (--> (Eq v r) r)
    (--> (If r e_0 e_1) r)))
 
 (define (bep ρ)
-  (union-reduction-relations 
+  (union-reduction-relations
    (extend-reduction-relation (b ρ) BE)
    err prop))
 \end{verbatim}

--- a/types.tex
+++ b/types.tex
@@ -60,7 +60,7 @@ classify phrases by \emph{the set of answers} they compute.
 
 For some simple languages, calculating such a set is trivial.  For
 example, for any $\Arith$ program $\mexp$, it's easy to compute the
-set $\{\mint\ |\ \mexp \Downarrow \mint \}$.  
+set $\{\mint\ |\ \mexp \Downarrow \mint \}$.
 %
 Even for $\Barith$, if we consider characterizing phrases $\mexp$ with
 a \emph{given environment} $\menv$, then it's easy to compute $\{
@@ -97,7 +97,7 @@ compute but rather by whether they compute:
 For example, $\Mult(3, 4)$ should be characterized as computing an
 integer.  $\If(\True,3,\False)$ computes a boolean.
 $\If(\mvar,3,\False)$ computes a boolean, an integer, or an error,
-dependending on the environment.
+depending on the environment.
 
 
 We therefore define the following \emph{abstract answers}:
@@ -123,7 +123,7 @@ Now let's explore an abstract evaluation relation for $\Barith$ based
 around the above notion of abstract values.  The idea here is that the
 formulate an alternative relation that operates on abstract values
 instead of values.  There are many abstract evaluation relations.
-What makes them admissable is if they are \emph{sound}, i.e. if it
+What makes them admissible is if they are \emph{sound}, i.e. if it
 possible for an expression to compute a certain kind of answer, that
 answer is in the (denotation) of the abstract answer.  Formally:
 
@@ -168,7 +168,7 @@ consider some concrete and abstract cases in tandem:
           {\vdash \mvar \Downarrow \Int}
 \end{mathpar}
 On the left is the concrete evaluation relation for variables, which
-are given meaning in terms of a particular environent.  The abstract
+are given meaning in terms of a particular environment.  The abstract
 evaluator must handle all possible environments; since an environment
 may map a variable to an integer or a boolean, the rule states that a
 variable occurrence may evaluate to either $\Bool$ or $\Int$.
@@ -192,7 +192,7 @@ Here are the concrete and abstract rules for literals:
 
 \inferrule{\ }
           {\vdash \mint \Downarrow \Int}
-          
+
 \inferrule{\ }
           {\vdash \mbool \Downarrow \Bool}
 \end{mathpar}
@@ -301,7 +301,7 @@ kind of evaluation relation, which gives an approximation of the
 expression evaluates to, the ``:'' says what set of values the result
 belongs to.  That intuition can guide the definition of the relation.
 So for example, an integer expression evaluates to something in
-$\Int$, and a Boolean evaluates to someting in $\Bool$:
+$\Int$, and a Boolean evaluates to something in $\Bool$:
 \begin{mathpar}
 \inferrule{\ }
           {\typevaljudge\menv\mint\Int}
@@ -381,7 +381,7 @@ does not produce an error.  By reasoning about a single ``abstract''
 run of the program, we can conclude facts about all possible
 ``concrete'' runs: none of them produce errors.
 
-We can make this claim precise with a relation on environments.  
+We can make this claim precise with a relation on environments.
 First, let's define:
 \begin{align*}
 \typeof(\mint) = \Int\\
@@ -396,7 +396,7 @@ variables to values of the same type:
 \end{mathpar}
 
 \begin{claim}
-If $\typevaljudge\menv\mexp\mtype$ and $\menv \sim \menv'$, then 
+If $\typevaljudge\menv\mexp\mtype$ and $\menv \sim \menv'$, then
 $\typevaljudge{\menv'}\mexp\mtype$.
 \end{claim}
 \begin{proof}
@@ -451,11 +451,11 @@ following error free programs:
 \If(\mathit{x},\If(\mathit{x},7,\Eq(\True,1)),8)\mbox{, where $\mathit{x}:\Bool$}
 \end{align*}
 
-\paragraph{Note on Runtime Errors:} 
+\paragraph{Note on Runtime Errors:}
 Type systems often only rule out a certain class of errors.  Which
 class depends on the particular type system.  The system we've just
 developed rules out all errors except $\Err_{\Div0}$ errors, which
-were ommitted from the presentation for simplicity.  To be precise
+were omitted from the presentation for simplicity.  To be precise
 about divide-by-zero errors would require some tedious and
 uninteresting additions to the semantics and conditions on the claims.
 
@@ -564,7 +564,7 @@ the original semantics more closely and explicitly characterize the
 error behavior of programs.
 
 Suppose we add rules corresponding the axioms for creating and
-propogating errors (only showing a small excerpt):
+propagating errors (only showing a small excerpt):
 \begin{mathpar}
 \inferrule{\mtype \neq \Bool}
           {\envreduce[\Gamma]{\If(\mtype,\mexp_1,\mexp_2)}{\treduce'}{\Err_{\If0}}}
@@ -599,7 +599,7 @@ If $\neg(\envreduce[\Gamma]\mexp{\multicompat{\treduce'}}\mtans)$ and $\Gamma\si
 $\neg(\envreduce\mexp{\multicompat{\breducename}}\mans)$ where $\mans \sqsubseteq \mtans$.
 \end{claim}
 We can also state this claim in an equivalent way which says that if a
-program can evaluate to some answer, then an appoximation of that
+program can evaluate to some answer, then an approximation of that
 answer is in the abstract evaluation of the program:
 \begin{claim}[Soundness]\label{claim:soundness}
 If $\envreduce\mexp{\multicompat{\breducename}}\mans$ and
@@ -650,7 +650,7 @@ semantics.)
 
 \subsection{Abstract Interpretation with Intervals}\label{sec:ai-intv}
 
-In this section, let's develop another abstract interperation of
+In this section, let's develop another abstract interpretation of
 $\Barith$, this time with a more refined abstract domain.  On
 integers, we'll use intervals and interpret the integer operations
 using interval arithmetic and on Booleans we'll do no approximation.
@@ -817,7 +817,7 @@ of integers:
 The type $\Int(\mintv)$ is known as a \deftech{refinement type}, which
 is a type qualified by a predicate which holds for every value of that
 type.  For our purposes, the predicates only include intervals, but
-richer refinement type systems can be defined by embeding richer
+richer refinement type systems can be defined by embedding richer
 logics of predicates into the types.  Refinement types, while not
 quite mainstream yet, are featured in several mature research project
 such as the refinement type system for F\# called
@@ -826,11 +826,11 @@ and a variant of Haskell with refinements called Liquid
 Haskell\footnote{\url{http://goto.ucsd.edu/~rjhala/liquid/haskell/blog/about/}}.
 
 To derive the type system from the reduction semantics, we start with
-a straightfoward reformulation of most of the axioms:
+a straightforward reformulation of most of the axioms:
 
 \begin{mathpar}
 \inferrule{\ }
-          {\typevaljudge\Gamma\mint{\Int(\mint,\mint)}}         
+          {\typevaljudge\Gamma\mint{\Int(\mint,\mint)}}
 
 \inferrule{\Gamma(\mvar) = \mtype}
           {\typevaljudge\Gamma\mvar{\mtype}}
@@ -894,7 +894,7 @@ This claim relies on the following definition of $\sqsubseteq$:
 
 \inferrule{\forall \mvar \in \dom(\menv).\menv(\mvar) \sqsubseteq \Gamma(\mvar) }
           {\menv \sqsubseteq \Gamma}
-          
+
 \end{mathpar}
 
 \begin{exercise}
@@ -973,7 +973,7 @@ actually be reached.
 The reduction of an expression is formulated as a reduction relation
 on expression and path condition pairs:
 $\envreduce[\relax]{(\mexp,\mpath)}\sreduce{(\mexp',\mpath')}$.  The
-meaning of such a reduction is that $\mexp$, under the assumptions of 
+meaning of such a reduction is that $\mexp$, under the assumptions of
 $\mpath$, may reduce to to $\mexp'$, implying conditions $\mpath'$.
 
 We use a relation on path conditions $\allows\mcon$, which denotes
@@ -1018,7 +1018,7 @@ satisfiability problem (SAT), which is just an instance of the SMT
 problem, using Boolean arithmetic as the underlying theory.  Other
 theories might include the theories of real numbers, intervals, data
 structures, and so on.  There are many mature SMT solvers available
-(e.g.~Z3, CVC4), which can effecitvely decide $\allows\mcon$.  If we
+(e.g.~Z3, CVC4), which can effectively decide $\allows\mcon$.  If we
 had a richer language, the path conditions would involve richer
 theories, which may not be decidable.  At that point, a sound
 approximation would need to be used.
@@ -1134,7 +1134,7 @@ Finally the fact that {\tt fact} is the argument to a multiplication
 operation also suggests it needs to produce an integer.
 
 In this informal analysis what we've done is collect a set of
-contraints on the usage of variables.  If that set of constraints is
+constraints on the usage of variables.  If that set of constraints is
 consistent, i.e. a variable is not used as an integer in one place and
 as a Boolean in another, then we conclude the program is type correct.
 This informal process can be made rigorous to produce a type inference
@@ -1202,7 +1202,7 @@ The remaining interesting rules are for variables and conditionals:
 A variable generates no constraints, because a variable occurrence
 alone doesn't imply anything about how the value of the variable is
 used.  But the type of a variable is just the variable's name.  So if
-the variable occurrs in some context that constrains its type, a type
+the variable occurs in some context that constrains its type, a type
 constraint will be generated for the variable.  For example,
 $\Pred(\mvar)$ generates the constraint $\mvar = \Int$.  If a variable
 occurs in multiple contexts that use the variable with different types
@@ -1225,7 +1225,7 @@ if the constraints have a solution.
 \newcommand\msubst{\psi}
 
 
-The general problem of determing if a set of equations between terms
+The general problem of determining if a set of equations between terms
 has a solution is known as the \deftech{unification problem}.
 %
 The way we will represent a solution to an instance of the unification
@@ -1246,13 +1246,13 @@ function, $\solve(\mcset)$:
 \begin{align}
 \unify(\emptyset,\msubst) &= \msubst\\
 \unify(\{\mtype = \mtype\}\cup\mcset,\msubst) &= \unify(\mcset,\msubst)\\
-\unify(\{\mvar  = \mtype\}\cup\mcset,\msubst) &= 
+\unify(\{\mvar  = \mtype\}\cup\mcset,\msubst) &=
 \begin{cases}
 \unify(\mcset,\msubst[\mtype/\mvar] \circ [\mvar \mapsto \mtype]) & \mbox{if }\msubst(\mvar) = \bot\\
 \unify(\mcset \cup \{ \mtype=\mtype' \},\msubst) & \mbox{if }\msubst(\mvar) = \mtype'\\
 \end{cases}\\
-\unify(\{\mtype = \mvar\}\cup\mcset,\msubst) &= 
-\unify(\{\mvar  = \mtype\}\cup\mcset,\msubst) 
+\unify(\{\mtype = \mvar\}\cup\mcset,\msubst) &=
+\unify(\{\mvar  = \mtype\}\cup\mcset,\msubst)
 \end{align}
 \end{gather*}
 
@@ -1267,7 +1267,7 @@ variable is already in the substitution, a new constraint is added to
 equate the type and what's given by the substitution.
 
 The unification is sound and complete: it produces a substitution
-whenver one exists, and the substitution produced is always a
+whenever one exists, and the substitution produced is always a
 solution.  If a solution exists, the program is well-typed under some
 typing environment:
 \begin{claim}
@@ -1276,7 +1276,7 @@ If $\typevaljudge\relax\mexp{\mtype,\mcset}$ and $\solve(\mcset) =
 $\typevaljudge\Gamma\mexp{\mtype'}$.
 \end{claim}
 
-The typing environment is \emph{almost} the same as the substituion
+The typing environment is \emph{almost} the same as the substitution
 $\msubst$, but we have to be a little careful about underconstrained
 variables.  For example in this program:
 $\If(\True,\mathit{x},\mathit{y})$, the variables $\mathit{x}$ and
@@ -1329,4 +1329,3 @@ a type environment.
 %% P(\menv,\mexp) \iff \menv \vdash \mexp =_\breducename \merr \text{, where } \merr \in \mathit{TypeError}\\
 %% Q(\mexp) \iff \exists \menv. \menv\text{ closes } \mexp\text{ and } \vdash \mexp =_\breducename \merr \text{, where } \merr \in \mathit{TypeError}
 %% \end{align*}
-


### PR DESCRIPTION
Spotted a few typos while reading the notes and thought I'd just scan the entire document, cherry pick a few typos the spell-checker found as well and do a pull request. Sorry for all the random spaces at the end of sentences that got deleted. My text-editor (I'm using Atom) did that automatically. I checked and it shouldn't cause any issues with the formatting.
